### PR TITLE
Fix undefined function array_get()

### DIFF
--- a/src/PageViewsMetric.php
+++ b/src/PageViewsMetric.php
@@ -26,7 +26,7 @@ class PageViewsMetric extends Value
             'YTD' => $this->pageViewsOneYear(),
         ];
 
-        $data = array_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+        $data = data_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
 
         return $this
             ->result($data['result'])

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -26,7 +26,7 @@ class VisitorsMetric extends Value
             'YTD' => $this->visitorsOneYear(),
         ];
 
-        $data = array_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+        $data = data_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
 
         return $this
             ->result($data['result'])


### PR DESCRIPTION
I'm using laravel 6 and I have this error:

```php
Call to undefined function Tightenco\NovaGoogleAnalytics\array_get() 
{"userId":1,"exception":"
[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): 
Call to undefined function Tightenco\\NovaGoogleAnalytics\\array_get() at 
/application/vendor/tightenco/nova-google-analytics/src/VisitorsMetric.php:29)
```
and:

```php
Call to undefined function Tightenco\NovaGoogleAnalytics\array_get() 
{"userId":1,"exception":"
[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): 
Call to undefined function Tightenco\\NovaGoogleAnalytics\\array_get() at 
/application/vendor/tightenco/nova-google-analytics/src/PageViewsMetric.php:29)
```
