### PR TITLE
Use array support class instead of helpers

### DIFF
--- a/src/PageViewsMetric.php
+++ b/src/PageViewsMetric.php
@@ -2,8 +2,8 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Laravel\Nova\Metrics\Value;
 use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;
@@ -26,7 +26,7 @@ class PageViewsMetric extends Value
             'YTD' => $this->pageViewsOneYear(),
         ];
 
-        $data = array_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+        $data = Arr::get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
 
         return $this
             ->result($data['result'])

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -2,7 +2,7 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Laravel\Nova\Metrics\Value;
 use Spatie\Analytics\Analytics;
@@ -26,7 +26,7 @@ class VisitorsMetric extends Value
             'YTD' => $this->visitorsOneYear(),
         ];
 
-        $data = array_get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+        $data = Arr::get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
 
         return $this
             ->result($data['result'])


### PR DESCRIPTION
Followup of #13 to support Laravel 6.0 without the `laravel/helpers` dependency