### PR TITLE
Fix Issue of Incorrect Statistics

### DIFF
--- a/src/PageViewsMetric.php
+++ b/src/PageViewsMetric.php
@@ -130,7 +130,7 @@ class PageViewsMetric extends Value
      */
     public function cacheFor()
     {
-        //return now()->addMinutes(30);
+        return now()->addMinutes(30);
     }
 
     /**

--- a/src/PageViewsMetric.php
+++ b/src/PageViewsMetric.php
@@ -2,6 +2,7 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Laravel\Nova\Metrics\Value;
@@ -46,8 +47,8 @@ class PageViewsMetric extends Value
 
     private function pageViewsOneMonth()
     {
-        $analyticsData = app(Analytics::class)->performQuery(
-            Period::months(1),
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfMonth(), Carbon::today()),
             'ga:pageviews',
             [
                 'metrics' => 'ga:pageviews',
@@ -55,18 +56,29 @@ class PageViewsMetric extends Value
             ]
         );
 
-        $results = collect($analyticsData->getRows());
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->subMonths(1)->startOfMonth(), Carbon::today()->subMonths(1)->endOfMonth()),
+            'ga:pageviews',
+            [
+                'metrics' => 'ga:pageviews',
+                'dimensions' => 'ga:yearMonth',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
 
         return [
-            'previous' => $results->first()[1],
-            'result' => $results->last()[1],
+            'previous' => $previousResults->last()[1],
+            'result' => $currentResults->last()[1],
         ];
     }
 
     private function pageViewsOneYear()
     {
-        $analyticsData = app(Analytics::class)->performQuery(
-            Period::years(1),
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfYear(), Carbon::today()),
             'ga:pageviews',
             [
                 'metrics' => 'ga:pageviews',
@@ -74,11 +86,22 @@ class PageViewsMetric extends Value
             ]
         );
 
-        $results = collect($analyticsData->getRows());
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->subYears(1)->startOfYear(), Carbon::today()->subYears(1)->endOfYear()),
+            'ga:pageviews',
+            [
+                'metrics' => 'ga:pageviews',
+                'dimensions' => 'ga:year',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
 
         return [
-            'previous' => $results->first()[1],
-            'result' => $results->last()[1],
+            'previous' => $previousResults->last()[1],
+            'result' => $currentResults->last()[1],
         ];
     }
 
@@ -107,7 +130,7 @@ class PageViewsMetric extends Value
      */
     public function cacheFor()
     {
-        return now()->addMinutes(30);
+        //return now()->addMinutes(30);
     }
 
     /**

--- a/src/PageViewsMetric.php
+++ b/src/PageViewsMetric.php
@@ -58,8 +58,9 @@ class PageViewsMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
+        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create(Carbon::today()->subMonths(1)->startOfMonth(), Carbon::today()->subMonths(1)->endOfMonth()),
+            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
             'ga:pageviews',
             [
                 'metrics' => 'ga:pageviews',
@@ -88,8 +89,9 @@ class PageViewsMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
+        $lastYear = Carbon::today()->startOfYear()->subYears(1);
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create(Carbon::today()->subYears(1)->startOfYear(), Carbon::today()->subYears(1)->endOfYear()),
+            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
             'ga:pageviews',
             [
                 'metrics' => 'ga:pageviews',

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -22,7 +22,7 @@ class VisitorsMetric extends Value
     public function calculate(Request $request)
     {
         $lookups = [
-            'TODAY' => $this->visitorsOneDay(),
+            1 => $this->visitorsOneDay(),
             'MTD' => $this->visitorsOneMonth(),
             'YTD' => $this->visitorsOneYear(),
         ];
@@ -116,7 +116,7 @@ class VisitorsMetric extends Value
     public function ranges()
     {
         return [
-            'TODAY' => 'Today',
+            1 => 'Today',
             // 30 => '30 Days',
             // 60 => '60 Days',
             // 365 => '365 Days',

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -61,8 +61,9 @@ class VisitorsMetric extends Value
         $currentResults = collect($currentAnalyticsData->getRows());
 
         // Then get the total results of last month to compare.
+        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create(Carbon::today()->subMonths(1)->startOfMonth(), Carbon::today()->subMonths(1)->endOfMonth()),
+            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
             'ga:users',
             [
                 'metrics' => 'ga:users',
@@ -91,8 +92,9 @@ class VisitorsMetric extends Value
         $currentResults = collect($currentAnalyticsData->getRows());
 
         // Then get the total results of last month to compare.
+        $lastYear = Carbon::today()->startOfYear()->subYears(1);
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create(Carbon::today()->subYears(1)->startOfYear(), Carbon::today()->subYears(1)->endOfYear()),
+            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
             'ga:users',
             [
                 'metrics' => 'ga:users',

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -133,7 +133,7 @@ class VisitorsMetric extends Value
      */
     public function cacheFor()
     {
-        // return now()->addMinutes(30);
+         return now()->addMinutes(30);
     }
 
     /**


### PR DESCRIPTION
This pull request will fix the issue of incorrect statistics being displayed by the page views and visitors metrics cards. The Month (to date) option will now compare the current month to date with the previous month. The Year (to date) option will now compare the current year to date with the previous year. Closes #19 

![Screen Shot 2021-01-15 at 9 13 33 AM](https://user-images.githubusercontent.com/7070136/104741982-e606c600-5717-11eb-927c-b7f78b6d64cb.png)
![Screen Shot 2021-01-15 at 9 55 57 AM](https://user-images.githubusercontent.com/7070136/104741985-e69f5c80-5717-11eb-9823-624a1bb2f4cf.png)
