### PR TITLE
Add two new metric cards for sessions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ public function cards()
         new \Tightenco\NovaGoogleAnalytics\VisitorsMetric,
         new \Tightenco\NovaGoogleAnalytics\MostVisitedPagesCard,
         new \Tightenco\NovaGoogleAnalytics\ReferrersList,
+        new \Tightenco\NovaGoogleAnalytics\SessionsMetric,
+        new \Tightenco\NovaGoogleAnalytics\SessionDurationMetric,
     ];
 }
 ```
@@ -59,6 +61,9 @@ public function cards()
 ## Features
 #### View the Visitors and Pageview Metrics
 ![image](https://user-images.githubusercontent.com/7070136/114229277-982fe180-9945-11eb-9c4c-ca9bc1554fca.png)
+
+#### View the Sessions and Avg. Session Duration Metrics
+![image](https://user-images.githubusercontent.com/7070136/122135144-f083d380-ce0d-11eb-9a30-bfa674e510e7.png)
 
 #### View the lists of Most Visited Pages and Referrers
 ![image](https://user-images.githubusercontent.com/7070136/114229279-982fe180-9945-11eb-9ee9-e38215ce5eae.png)

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "laravel/nova": "*",
         "orchestra/testbench": "^6.13",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "tightenco/tlint": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/dist/css/tool.css
+++ b/dist/css/tool.css
@@ -1,0 +1,1 @@
+// Nova Tool CSS

--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -60,18 +60,20 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ 	return __webpack_require__(__webpack_require__.s = 153);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
+/******/ ({
+
+/***/ 153:
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(1);
+module.exports = __webpack_require__(154);
 
 
 /***/ }),
-/* 1 */
+
+/***/ 154:
 /***/ (function(module, exports) {
 
 Nova.booting(function (Vue, router) {
@@ -85,4 +87,5 @@ Nova.booting(function (Vue, router) {
 });
 
 /***/ })
-/******/ ]);
+
+/******/ });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Tightenco\NovaGoogleAnalytics\Http\Controllers\MostVisitedPagesController;
 use Tightenco\NovaGoogleAnalytics\Http\Controllers\ReferrerListController;

--- a/src/CardServiceProvider.php
+++ b/src/CardServiceProvider.php
@@ -2,9 +2,8 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Illuminate\Support\Facades\Log;
-use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Nova;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -22,7 +21,7 @@ class CardServiceProvider extends ServiceProvider
         });
 
         Nova::serving(function (ServingNova $event) {
-            Nova::script('nova-google-analytics-card', __DIR__.'/../dist/js/card.js');
+            Nova::script('nova-google-analytics-card', __DIR__ . '/../dist/js/card.js');
             // Nova::style('nova-google-analytics-card', __DIR__.'/../dist/css/card.css');
         });
     }
@@ -40,7 +39,7 @@ class CardServiceProvider extends ServiceProvider
 
         Route::middleware(['nova'])
                 ->prefix('nova-vendor/nova-google-analytics')
-                ->group(__DIR__.'/../routes/api.php');
+                ->group(__DIR__ . '/../routes/api.php');
     }
 
     /**

--- a/src/Http/Controllers/MostVisitedPagesController.php
+++ b/src/Http/Controllers/MostVisitedPagesController.php
@@ -3,7 +3,6 @@
 namespace Tightenco\NovaGoogleAnalytics\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Tightenco\NovaGoogleAnalytics\File;
 use Illuminate\Routing\Controller;
 use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;

--- a/src/Http/Controllers/ReferrerListController.php
+++ b/src/Http/Controllers/ReferrerListController.php
@@ -3,7 +3,6 @@
 namespace Tightenco\NovaGoogleAnalytics\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Tightenco\NovaGoogleAnalytics\File;
 use Illuminate\Routing\Controller;
 use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;

--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -4,8 +4,8 @@ namespace Tightenco\NovaGoogleAnalytics\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Tightenco\NovaGoogleAnalytics\Tool;
 use Symfony\Component\HttpFoundation\Response;
+use Tightenco\NovaGoogleAnalytics\Tool;
 
 class Authorize
 {

--- a/src/MetricDiffTrait.php
+++ b/src/MetricDiffTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Carbon\Carbon;
+
+trait MetricDiffTrait
+{
+    private function getPeriodDiff($startDate) {
+        $currentPeriodDiff = $startDate->diffInDays(Carbon::today());
+        $end = Carbon::yesterday()->subDays($currentPeriodDiff);
+        $start = Carbon::yesterday()->subDays($currentPeriodDiff)->subDays($currentPeriodDiff);
+
+        return [$start, $end];
+    }
+}

--- a/src/ReferrersList.php
+++ b/src/ReferrersList.php
@@ -2,12 +2,7 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Carbon\Carbon;
-use Illuminate\Http\Request;
-use Spatie\Analytics\Analytics;
 use Laravel\Nova\Card;
-use Spatie\Analytics\Period;
-use Laravel\Nova\Metrics\Value;
 
 class ReferrersList extends Card
 {

--- a/src/SessionDurationMetric.php
+++ b/src/SessionDurationMetric.php
@@ -13,7 +13,8 @@ use Spatie\Analytics\Period;
 
 class SessionDurationMetric extends Value
 {
-    public function name() {
+    public function name()
+    {
         return __('Avg. Session Duration');
     }
 

--- a/src/SessionDurationMetric.php
+++ b/src/SessionDurationMetric.php
@@ -1,0 +1,158 @@
+<?php
+
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Laravel\Nova\Metrics\Value;
+use Laravel\Nova\Metrics\ValueResult;
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+
+class SessionDurationMetric extends Value
+{
+    public function name() {
+        return __('Avg. Session Duration');
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $lookups = [
+            1 => $this->sessionDurationOneDay(),
+            'MTD' => $this->sessionDurationOneMonth(),
+            'YTD' => $this->sessionDurationOneYear(),
+        ];
+
+        $data = Arr::get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+
+        return (new ValueResult($data['result']))->previous($data['previous'])->format('00:00:00');
+    }
+
+    private function sessionDurationOneDay()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(1),
+                'ga:avgSessionDuration',
+                [
+                    'metrics' => 'ga:avgSessionDuration',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $results = collect($analyticsData->getRows());
+
+        return [
+            'result' => $results->last()[1] ?? 0,
+            'previous' => $results->first()[1] ?? 0,
+        ];
+    }
+
+    private function sessionDurationOneMonth()
+    {
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfMonth(), Carbon::today()),
+            'ga:avgSessionDuration',
+            [
+                'metrics' => 'ga:avgSessionDuration',
+                'dimensions' => 'ga:yearMonth',
+            ]
+        );
+
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
+            'ga:avgSessionDuration',
+            [
+                'metrics' => 'ga:avgSessionDuration',
+                'dimensions' => 'ga:yearMonth',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
+
+        return [
+            'previous' => $previousResults->last()[1] ?? 0,
+            'result' => $currentResults->last()[1] ?? 0,
+        ];
+    }
+
+    private function sessionDurationOneYear()
+    {
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfYear(), Carbon::today()),
+            'ga:avgSessionDuration',
+            [
+                'metrics' => 'ga:avgSessionDuration',
+                'dimensions' => 'ga:year',
+            ]
+        );
+
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $lastYear = Carbon::today()->startOfYear()->subYears(1);
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
+            'ga:avgSessionDuration',
+            [
+                'metrics' => 'ga:avgSessionDuration',
+                'dimensions' => 'ga:year',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
+
+        return [
+            'previous' => $previousResults->last()[1] ?? 0,
+            'result' => $currentResults->last()[1] ?? 0,
+        ];
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            1 => __('Today'),
+            'MTD' => __('Month To Date'),
+            // 60 => '60 Days',
+            'YTD' => __('Year To Date'),
+            // 'MTD' => 'Month To Date',
+            // 'QTD' => 'Quarter To Date',
+            // 'YTD' => 'Year To Date',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        return now()->addMinutes(30);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'session-duration';
+    }
+}

--- a/src/SessionDurationMetric.php
+++ b/src/SessionDurationMetric.php
@@ -13,6 +13,8 @@ use Spatie\Analytics\Period;
 
 class SessionDurationMetric extends Value
 {
+    use MetricDiffTrait;
+
     public function name()
     {
         return __('Avg. Session Duration');
@@ -70,9 +72,9 @@ class SessionDurationMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
-        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
+        [$start, $end] = $this->getPeriodDiff(Carbon::today()->startOfMonth());
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
+            Period::create($start, $end),
             'ga:avgSessionDuration',
             [
                 'metrics' => 'ga:avgSessionDuration',
@@ -101,9 +103,9 @@ class SessionDurationMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
-        $lastYear = Carbon::today()->startOfYear()->subYears(1);
+        [$start, $end] = $this->getPeriodDiff(Carbon::today()->startOfYear());
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
+            Period::create($start, $end),
             'ga:avgSessionDuration',
             [
                 'metrics' => 'ga:avgSessionDuration',

--- a/src/SessionsByCountryMetric.php
+++ b/src/SessionsByCountryMetric.php
@@ -30,8 +30,8 @@ class SessionsByCountryMetric extends Partition
                     'metrics' => 'ga:sessions',
                     'dimensions' => 'ga:country',
                     'sort' => '-ga:sessions',
-                    'max-results' => 5
-                ]
+                    'max-results' => 5,
+                ],
             );
 
         $rows = collect($analyticsData->getRows());

--- a/src/SessionsMetric.php
+++ b/src/SessionsMetric.php
@@ -11,7 +11,8 @@ use Spatie\Analytics\Period;
 
 class SessionsMetric extends Value
 {
-    public function name() {
+    public function name()
+    {
         return __('Sessions');
     }
 

--- a/src/SessionsMetric.php
+++ b/src/SessionsMetric.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Laravel\Nova\Metrics\Value;
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+
+class SessionsMetric extends Value
+{
+    public function name() {
+        return __('Sessions');
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $lookups = [
+            1 => $this->sessionsOneDay(),
+            'MTD' => $this->sessionsOneMonth(),
+            'YTD' => $this->sessionsOneYear(),
+        ];
+
+        $data = Arr::get($lookups, $request->get('range'), ['result' => 0, 'previous' => 0]);
+
+        return $this
+            ->result($data['result'])
+            ->previous($data['previous']);
+    }
+
+    private function sessionsOneDay()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(1),
+                'ga:sessions',
+                [
+                    'metrics' => 'ga:sessions',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $results = collect($analyticsData->getRows());
+
+        return [
+            'result' => $results->last()[1] ?? 0,
+            'previous' => $results->first()[1] ?? 0,
+        ];
+    }
+
+    private function sessionsOneMonth()
+    {
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfMonth(), Carbon::today()),
+            'ga:sessions',
+            [
+                'metrics' => 'ga:sessions',
+                'dimensions' => 'ga:yearMonth',
+            ]
+        );
+
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
+            'ga:sessions',
+            [
+                'metrics' => 'ga:sessions',
+                'dimensions' => 'ga:yearMonth',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
+
+        return [
+            'previous' => $previousResults->last()[1] ?? 0,
+            'result' => $currentResults->last()[1] ?? 0,
+        ];
+    }
+
+    private function sessionsOneYear()
+    {
+        $currentAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create(Carbon::today()->startOfYear(), Carbon::today()),
+            'ga:sessions',
+            [
+                'metrics' => 'ga:sessions',
+                'dimensions' => 'ga:year',
+            ]
+        );
+
+        $currentResults = collect($currentAnalyticsData->getRows());
+
+        $lastYear = Carbon::today()->startOfYear()->subYears(1);
+        $previousAnalyticsData = app(Analytics::class)->performQuery(
+            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
+            'ga:sessions',
+            [
+                'metrics' => 'ga:sessions',
+                'dimensions' => 'ga:year',
+            ]
+        );
+
+        $previousResults = collect($previousAnalyticsData->getRows());
+
+        return [
+            'previous' => $previousResults->last()[1] ?? 0,
+            'result' => $currentResults->last()[1] ?? 0,
+        ];
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            1 => __('Today'),
+            'MTD' => __('Month To Date'),
+            // 60 => '60 Days',
+            'YTD' => __('Year To Date'),
+            // 'MTD' => 'Month To Date',
+            // 'QTD' => 'Quarter To Date',
+            // 'YTD' => 'Year To Date',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        return now()->addMinutes(30);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'sessions';
+    }
+}

--- a/src/SessionsMetric.php
+++ b/src/SessionsMetric.php
@@ -11,6 +11,8 @@ use Spatie\Analytics\Period;
 
 class SessionsMetric extends Value
 {
+    use MetricDiffTrait;
+
     public function name()
     {
         return __('Sessions');
@@ -70,9 +72,9 @@ class SessionsMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
-        $lastMonth = Carbon::today()->startOfMonth()->subMonths(1);
+        [$start, $end] = $this->getPeriodDiff(Carbon::today()->startOfMonth());
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create($lastMonth->startOfMonth(), $lastMonth->endOfMonth()),
+            Period::create($start, $end),
             'ga:sessions',
             [
                 'metrics' => 'ga:sessions',
@@ -101,9 +103,9 @@ class SessionsMetric extends Value
 
         $currentResults = collect($currentAnalyticsData->getRows());
 
-        $lastYear = Carbon::today()->startOfYear()->subYears(1);
+        [$start, $end] = $this->getPeriodDiff(Carbon::today()->startOfYear());
         $previousAnalyticsData = app(Analytics::class)->performQuery(
-            Period::create($lastYear->startOfYear(), $lastYear->endOfYear()),
+            Period::create($start, $end),
             'ga:sessions',
             [
                 'metrics' => 'ga:sessions',

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -14,8 +14,8 @@ class Tool extends BaseTool
      */
     public function boot()
     {
-        Nova::script('nova-google-analytics', __DIR__.'/../dist/js/tool.js');
-        Nova::style('nova-google-analytics', __DIR__.'/../dist/css/tool.css');
+        Nova::script('nova-google-analytics', __DIR__ . '/../dist/js/tool.js');
+        Nova::style('nova-google-analytics', __DIR__ . '/../dist/css/tool.css');
     }
 
     /**

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -2,10 +2,10 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Laravel\Nova\Nova;
-use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Nova;
 use Tightenco\NovaGoogleAnalytics\Http\Middleware\Authorize;
 
 class ToolServiceProvider extends ServiceProvider
@@ -17,7 +17,7 @@ class ToolServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-google-analytics');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'nova-google-analytics');
 
         $this->app->booted(function () {
             $this->routes();
@@ -41,7 +41,7 @@ class ToolServiceProvider extends ServiceProvider
 
         Route::middleware(['nova', Authorize::class])
                 ->prefix('nova-vendor/tightenco/nova-google-analytics')
-                ->group(__DIR__.'/../routes/api.php');
+                ->group(__DIR__ . '/../routes/api.php');
     }
 
     /**

--- a/src/VisitorsMetric.php
+++ b/src/VisitorsMetric.php
@@ -2,12 +2,12 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Illuminate\Support\Arr;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Laravel\Nova\Metrics\Value;
 use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;
-use Carbon\Carbon;
 
 class VisitorsMetric extends Value
 {

--- a/tests/SessionDurationMetricTest.php
+++ b/tests/SessionDurationMetricTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics\Tests;
+
+use Tightenco\NovaGoogleAnalytics\SessionDurationMetric;
+
+class SessionDurationMetricTest extends TestCase
+{
+    /** @test */
+    public function it_can_return_results_for_one_day()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function one_day_results_contain_previous()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function one_day_results_contain_value()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+
+    /** @test */
+    public function it_can_return_results_mtd()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function mtd_results_contain_previous()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function mtd_results_contain_value()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+
+    /** @test */
+    public function it_can_return_results_ytd()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function ytd_results_contain_previous()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function ytd_results_contain_value()
+    {
+        $response = (new SessionDurationMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+}

--- a/tests/SessionsMetricTest.php
+++ b/tests/SessionsMetricTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics\Tests;
+
+use Tightenco\NovaGoogleAnalytics\SessionsMetric;
+
+class SessionsMetricTest extends TestCase
+{
+    /** @test */
+    public function it_can_return_results_for_one_day()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function one_day_results_contain_previous()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function one_day_results_contain_value()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => '1']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+
+    /** @test */
+    public function it_can_return_results_mtd()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function mtd_results_contain_previous()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function mtd_results_contain_value()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'MTD']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+
+    /** @test */
+    public function it_can_return_results_ytd()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertFalse(empty($response));
+    }
+
+    /** @test */
+    public function ytd_results_contain_previous()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertObjectHasAttribute('previous', $response);
+    }
+
+    /** @test */
+    public function ytd_results_contain_value()
+    {
+        $response = (new SessionsMetric)->calculate($this->requestWithQueryParams(['range' => 'YTD']));
+        $this->assertObjectHasAttribute('value', $response);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,11 @@ namespace Tightenco\NovaGoogleAnalytics\Tests;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Tightenco\NovaGoogleAnalytics\CardServiceProvider;
-use Tightenco\NovaGoogleAnalytics\ToolServiceProvider;
 use Spatie\Analytics\AnalyticsFacade;
 use Spatie\Analytics\AnalyticsServiceProvider;
+use Tightenco\NovaGoogleAnalytics\CardServiceProvider;
+use Tightenco\NovaGoogleAnalytics\ToolServiceProvider;
 
 abstract class TestCase extends Orchestra
 {


### PR DESCRIPTION
This pull request adds two new metric cards: Sessions and Avg. Session Duration. 

False Data is included in the screenshot below to show the format and style of the cards.

![Screen Shot 2021-06-15 at 7 11 07 PM](https://user-images.githubusercontent.com/7070136/122135144-f083d380-ce0d-11eb-9a30-bfa674e510e7.png)
