### PR TITLE
Add Active User Trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ public function cards()
         new \Tightenco\NovaGoogleAnalytics\VisitorsMetric,
         new \Tightenco\NovaGoogleAnalytics\MostVisitedPagesCard,
         new \Tightenco\NovaGoogleAnalytics\ReferrersList,
+        new \Tightenco\NovaGoogleAnalytics\OneDayActiveUsersMetric,
+        new \Tightenco\NovaGoogleAnalytics\SevenDayActiveUsersMetric,
+        new \Tightenco\NovaGoogleAnalytics\FourteenDayActiveUsersMetric,
+        new \Tightenco\NovaGoogleAnalytics\TwentyEightDayActiveUsersMetric,
     ];
 }
 ```
@@ -59,6 +63,10 @@ public function cards()
 ## Features
 #### View the Visitors and Pageview Metrics
 ![image](https://user-images.githubusercontent.com/7070136/114229277-982fe180-9945-11eb-9c4c-ca9bc1554fca.png)
+
+#### View the Active Users Metrics
+![image](https://user-images.githubusercontent.com/7070136/122437531-cc3c0a00-cf67-11eb-883b-6fdb56122142.png)
+![image](https://user-images.githubusercontent.com/7070136/122437540-ce05cd80-cf67-11eb-8bc9-775a13db068e.png)
 
 #### View the lists of Most Visited Pages and Referrers
 ![image](https://user-images.githubusercontent.com/7070136/114229279-982fe180-9945-11eb-9ee9-e38215ce5eae.png)

--- a/src/ActiveUsersTrait.php
+++ b/src/ActiveUsersTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+use Carbon\Carbon;
+
+trait ActiveUsersTrait
+{
+    private function performQuery($metric, $days)
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days($days),
+                $metric,
+                [
+                    'metrics' => $metric,
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+}

--- a/src/ActiveUsersTrait.php
+++ b/src/ActiveUsersTrait.php
@@ -2,13 +2,13 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
+use Carbon\Carbon;
 use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;
-use Carbon\Carbon;
 
 trait ActiveUsersTrait
 {
-    private function performQuery($metric, $days)
+    private function performQuery(string $metric, int $days): array
     {
         $analyticsData = app(Analytics::class)
             ->performQuery(
@@ -22,7 +22,7 @@ trait ActiveUsersTrait
 
         $results = collect($analyticsData->getRows())->mapWithKeys(function ($row) {
             return [
-                (new Carbon($row[0]))->format('M j') => intval($row[1])
+                (new Carbon($row[0]))->format('M j') => intval($row[1]),
             ];
         });
 

--- a/src/ActiveUsersTrait.php
+++ b/src/ActiveUsersTrait.php
@@ -20,14 +20,12 @@ trait ActiveUsersTrait
                 ]
             );
 
-        $rows = collect($analyticsData->getRows());
+        $results = collect($analyticsData->getRows())->mapWithKeys(function ($row) {
+            return [
+                (new Carbon($row[0]))->format('M j') => intval($row[1])
+            ];
+        });
 
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
+        return ['results' => $results->toArray()];
     }
 }

--- a/src/FourteenDayActiveUsersMetric.php
+++ b/src/FourteenDayActiveUsersMetric.php
@@ -12,7 +12,8 @@ use Carbon\Carbon;
 
 class FourteenDayActiveUsersMetric extends Trend
 {
-    public function name() {
+    public function name()
+    {
         return __('14 Day Active Users');
     }
 

--- a/src/FourteenDayActiveUsersMetric.php
+++ b/src/FourteenDayActiveUsersMetric.php
@@ -2,13 +2,10 @@
 
 namespace Tightenco\NovaGoogleAnalytics;
 
-use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Laravel\Nova\Metrics\Trend;
 use Laravel\Nova\Metrics\TrendResult;
-use Spatie\Analytics\Analytics;
-use Spatie\Analytics\Period;
-use Carbon\Carbon;
 
 class FourteenDayActiveUsersMetric extends Trend
 {

--- a/src/FourteenDayActiveUsersMetric.php
+++ b/src/FourteenDayActiveUsersMetric.php
@@ -12,6 +12,8 @@ use Carbon\Carbon;
 
 class FourteenDayActiveUsersMetric extends Trend
 {
+    use ActiveUsersTrait;
+
     public function name()
     {
         return __('14 Day Active Users');
@@ -26,9 +28,9 @@ class FourteenDayActiveUsersMetric extends Trend
     public function calculate(Request $request)
     {
         $lookups = [
-            5 => $this->activeUsersFiveDays(),
-            10 => $this->activeUsersTenDays(),
-            15 => $this->activeUsersFifteenDays(),
+            5 => $this->performQuery('ga:14dayUsers', 5),
+            10 => $this->performQuery('ga:14dayUsers', 10),
+            15 => $this->performQuery('ga:14dayUsers', 15),
         ];
 
         $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
@@ -36,75 +38,6 @@ class FourteenDayActiveUsersMetric extends Trend
         return (new TrendResult)->trend($data['results'])
             ->showLatestValue()
             ->format('0,0');
-    }
-
-    private function activeUsersFiveDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(5),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:14dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersTenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(10),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:14dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersFifteenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(15),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:14dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
     }
 
     /**

--- a/src/FourteenDayActiveUsersMetric.php
+++ b/src/FourteenDayActiveUsersMetric.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Trend;
+use Laravel\Nova\Metrics\TrendResult;
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+use Carbon\Carbon;
+
+class FourteenDayActiveUsersMetric extends Trend
+{
+    public function name() {
+        return __('14 Day Active Users');
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $lookups = [
+            5 => $this->activeUsersFiveDays(),
+            10 => $this->activeUsersTenDays(),
+            15 => $this->activeUsersFifteenDays(),
+        ];
+
+        $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
+
+        return (new TrendResult)->trend($data['results'])
+            ->showLatestValue()
+            ->format('0,0');
+    }
+
+    private function activeUsersFiveDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(5),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:14dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersTenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(10),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:14dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersFifteenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(15),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:14dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            5 => '5 Days',
+            10 => '10 Days',
+            15 => '15 Days',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        return now()->addMinutes(30);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'fourteen-day-active-users';
+    }
+}

--- a/src/OneDayActiveUsersMetric.php
+++ b/src/OneDayActiveUsersMetric.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Carbon\Traits\Creator;
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Trend;
+use Laravel\Nova\Metrics\TrendResult;
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+use Carbon\Carbon;
+
+class OneDayActiveUsersMetric extends Trend
+{
+    public function name() {
+        return __('1 Day Active Users');
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $lookups = [
+            5 => $this->activeUsersFiveDays(),
+            10 => $this->activeUsersTenDays(),
+            15 => $this->activeUsersFifteenDays(),
+        ];
+
+        $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
+
+        return (new TrendResult)->trend($data['results'])
+            ->showLatestValue()
+            ->format('0,0');
+    }
+
+    private function activeUsersFiveDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(5),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:1dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersTenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(10),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:1dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersFifteenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(15),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:1dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            5 => '5 Days',
+            10 => '10 Days',
+            15 => '15 Days',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        //return now()->addMinutes(30);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'one-day-active-users';
+    }
+}

--- a/src/OneDayActiveUsersMetric.php
+++ b/src/OneDayActiveUsersMetric.php
@@ -12,7 +12,8 @@ use Carbon\Carbon;
 
 class OneDayActiveUsersMetric extends Trend
 {
-    public function name() {
+    public function name()
+    {
         return __('1 Day Active Users');
     }
 

--- a/src/OneDayActiveUsersMetric.php
+++ b/src/OneDayActiveUsersMetric.php
@@ -6,12 +6,11 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Laravel\Nova\Metrics\Trend;
 use Laravel\Nova\Metrics\TrendResult;
-use Spatie\Analytics\Analytics;
-use Spatie\Analytics\Period;
-use Carbon\Carbon;
 
 class OneDayActiveUsersMetric extends Trend
 {
+    use ActiveUsersTrait;
+
     public function name()
     {
         return __('1 Day Active Users');
@@ -26,9 +25,9 @@ class OneDayActiveUsersMetric extends Trend
     public function calculate(Request $request)
     {
         $lookups = [
-            5 => $this->activeUsersFiveDays(),
-            10 => $this->activeUsersTenDays(),
-            15 => $this->activeUsersFifteenDays(),
+            5 => $this->performQuery('ga:1dayUsers', 5),
+            10 => $this->performQuery('ga:1dayUsers', 10),
+            15 => $this->performQuery('ga:1dayUsers', 15),
         ];
 
         $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
@@ -36,75 +35,6 @@ class OneDayActiveUsersMetric extends Trend
         return (new TrendResult)->trend($data['results'])
             ->showLatestValue()
             ->format('0,0');
-    }
-
-    private function activeUsersFiveDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(5),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:1dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersTenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(10),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:1dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersFifteenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(15),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:1dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
     }
 
     /**

--- a/src/SevenDayActiveUsersMetric.php
+++ b/src/SevenDayActiveUsersMetric.php
@@ -12,7 +12,8 @@ use Carbon\Carbon;
 
 class SevenDayActiveUsersMetric extends Trend
 {
-    public function name() {
+    public function name()
+    {
         return __('7 Day Active Users');
     }
 

--- a/src/SevenDayActiveUsersMetric.php
+++ b/src/SevenDayActiveUsersMetric.php
@@ -10,10 +10,10 @@ use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;
 use Carbon\Carbon;
 
-class OneDayActiveUsersMetric extends Trend
+class SevenDayActiveUsersMetric extends Trend
 {
     public function name() {
-        return __('1 Day Active Users');
+        return __('7 Day Active Users');
     }
 
     /**
@@ -44,7 +44,7 @@ class OneDayActiveUsersMetric extends Trend
                 Period::days(5),
                 'ga:1dayUsers',
                 [
-                    'metrics' => 'ga:1dayUsers',
+                    'metrics' => 'ga:7dayUsers',
                     'dimensions' => 'ga:date',
                 ]
             );
@@ -67,7 +67,7 @@ class OneDayActiveUsersMetric extends Trend
                 Period::days(10),
                 'ga:1dayUsers',
                 [
-                    'metrics' => 'ga:1dayUsers',
+                    'metrics' => 'ga:7dayUsers',
                     'dimensions' => 'ga:date',
                 ]
             );
@@ -90,7 +90,7 @@ class OneDayActiveUsersMetric extends Trend
                 Period::days(15),
                 'ga:1dayUsers',
                 [
-                    'metrics' => 'ga:1dayUsers',
+                    'metrics' => 'ga:7dayUsers',
                     'dimensions' => 'ga:date',
                 ]
             );
@@ -137,6 +137,6 @@ class OneDayActiveUsersMetric extends Trend
      */
     public function uriKey()
     {
-        return 'one-day-active-users';
+        return 'seven-day-active-users';
     }
 }

--- a/src/SevenDayActiveUsersMetric.php
+++ b/src/SevenDayActiveUsersMetric.php
@@ -12,6 +12,8 @@ use Carbon\Carbon;
 
 class SevenDayActiveUsersMetric extends Trend
 {
+    use ActiveUsersTrait;
+
     public function name()
     {
         return __('7 Day Active Users');
@@ -26,9 +28,9 @@ class SevenDayActiveUsersMetric extends Trend
     public function calculate(Request $request)
     {
         $lookups = [
-            5 => $this->activeUsersFiveDays(),
-            10 => $this->activeUsersTenDays(),
-            15 => $this->activeUsersFifteenDays(),
+            5 => $this->performQuery('ga:7dayUsers', 5),
+            10 => $this->performQuery('ga:7dayUsers', 10),
+            15 => $this->performQuery('ga:7dayUsers', 15),
         ];
 
         $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
@@ -36,75 +38,6 @@ class SevenDayActiveUsersMetric extends Trend
         return (new TrendResult)->trend($data['results'])
             ->showLatestValue()
             ->format('0,0');
-    }
-
-    private function activeUsersFiveDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(5),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:7dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersTenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(10),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:7dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersFifteenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(15),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:7dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
     }
 
     /**

--- a/src/TwentyEightDayActiveUsersMetric.php
+++ b/src/TwentyEightDayActiveUsersMetric.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tightenco\NovaGoogleAnalytics;
+
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Laravel\Nova\Metrics\Trend;
+use Laravel\Nova\Metrics\TrendResult;
+use Spatie\Analytics\Analytics;
+use Spatie\Analytics\Period;
+use Carbon\Carbon;
+
+class TwentyEightDayActiveUsersMetric extends Trend
+{
+    public function name() {
+        return __('28 Day Active Users');
+    }
+
+    /**
+     * Calculate the value of the metric.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function calculate(Request $request)
+    {
+        $lookups = [
+            5 => $this->activeUsersFiveDays(),
+            10 => $this->activeUsersTenDays(),
+            15 => $this->activeUsersFifteenDays(),
+        ];
+
+        $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
+
+        return (new TrendResult)->trend($data['results'])
+            ->showLatestValue()
+            ->format('0,0');
+    }
+
+    private function activeUsersFiveDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(5),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:28dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersTenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(10),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:28dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    private function activeUsersFifteenDays()
+    {
+        $analyticsData = app(Analytics::class)
+            ->performQuery(
+                Period::days(15),
+                'ga:1dayUsers',
+                [
+                    'metrics' => 'ga:28dayUsers',
+                    'dimensions' => 'ga:date',
+                ]
+            );
+
+        $rows = collect($analyticsData->getRows());
+
+        $results = [];
+        foreach ($rows as $row) {
+            $date = new Carbon($row[0]);
+            $results[$date->format('M j')] = intval($row[1]);
+        }
+
+        return ['results' => $results];
+    }
+
+    /**
+     * Get the ranges available for the metric.
+     *
+     * @return array
+     */
+    public function ranges()
+    {
+        return [
+            5 => '5 Days',
+            10 => '10 Days',
+            15 => '15 Days',
+        ];
+    }
+
+    /**
+     * Determine for how many minutes the metric should be cached.
+     *
+     * @return  \DateTimeInterface|\DateInterval|float|int
+     */
+    public function cacheFor()
+    {
+        return now()->addMinutes(30);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     *
+     * @return string
+     */
+    public function uriKey()
+    {
+        return 'twenty-eight-day-active-users';
+    }
+}

--- a/src/TwentyEightDayActiveUsersMetric.php
+++ b/src/TwentyEightDayActiveUsersMetric.php
@@ -12,7 +12,8 @@ use Carbon\Carbon;
 
 class TwentyEightDayActiveUsersMetric extends Trend
 {
-    public function name() {
+    public function name()
+    {
         return __('28 Day Active Users');
     }
 

--- a/src/TwentyEightDayActiveUsersMetric.php
+++ b/src/TwentyEightDayActiveUsersMetric.php
@@ -12,6 +12,8 @@ use Carbon\Carbon;
 
 class TwentyEightDayActiveUsersMetric extends Trend
 {
+    use ActiveUsersTrait;
+
     public function name()
     {
         return __('28 Day Active Users');
@@ -26,9 +28,9 @@ class TwentyEightDayActiveUsersMetric extends Trend
     public function calculate(Request $request)
     {
         $lookups = [
-            5 => $this->activeUsersFiveDays(),
-            10 => $this->activeUsersTenDays(),
-            15 => $this->activeUsersFifteenDays(),
+            5 => $this->performQuery('ga:28dayUsers', 5),
+            10 => $this->performQuery('ga:28dayUsers', 10),
+            15 => $this->performQuery('ga:28dayUsers', 15),
         ];
 
         $data = Arr::get($lookups, $request->get('range'), ['results' => [0]]);
@@ -36,75 +38,6 @@ class TwentyEightDayActiveUsersMetric extends Trend
         return (new TrendResult)->trend($data['results'])
             ->showLatestValue()
             ->format('0,0');
-    }
-
-    private function activeUsersFiveDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(5),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:28dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersTenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(10),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:28dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
-    }
-
-    private function activeUsersFifteenDays()
-    {
-        $analyticsData = app(Analytics::class)
-            ->performQuery(
-                Period::days(15),
-                'ga:1dayUsers',
-                [
-                    'metrics' => 'ga:28dayUsers',
-                    'dimensions' => 'ga:date',
-                ]
-            );
-
-        $rows = collect($analyticsData->getRows());
-
-        $results = [];
-        foreach ($rows as $row) {
-            $date = new Carbon($row[0]);
-            $results[$date->format('M j')] = intval($row[1]);
-        }
-
-        return ['results' => $results];
     }
 
     /**


### PR DESCRIPTION
This pull request adds the following trend metrics as available cards for the dashboard:

1. 1 Day Active Users
2. 7 Day Active Users
3. 14 Day Active Users
4. 28 Day Active Users

Below are screenshots of the new metric cards with fake data to show the cards working.

![Screen Shot 2021-06-17 at 11 34 48 AM](https://user-images.githubusercontent.com/7070136/122437531-cc3c0a00-cf67-11eb-883b-6fdb56122142.png)
![Screen Shot 2021-06-17 at 12 24 42 PM](https://user-images.githubusercontent.com/7070136/122437540-ce05cd80-cf67-11eb-8bc9-775a13db068e.png)
