### PR TITLE
Add PHP 8-only Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [8.0]
         include:
           - laravel: 6.*
             testbench: 4.*

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "spatie/laravel-analytics": "^3.6"
+        "php": "^8.0",
+        "spatie/laravel-analytics": "^4.0"
     },
     "require-dev": {
         "laravel/nova": "*",


### PR DESCRIPTION
This PR adds a new major version, v1.0.0.

Specifically, it:

Removes support for all PHP 7.x versions.
Requires PHP 8.0+.