### PR TITLE
Add translations for metric ranges.

### DIFF
--- a/src/FourteenDayActiveUsersMetric.php
+++ b/src/FourteenDayActiveUsersMetric.php
@@ -34,9 +34,9 @@ class FourteenDayActiveUsersMetric extends Trend
     public function ranges(): array
     {
         return [
-            5 => '5 Days',
-            10 => '10 Days',
-            15 => '15 Days',
+            5 => __('5 Days'),
+            10 => __('10 Days'),
+            15 => __('15 Days'),
         ];
     }
 

--- a/src/OneDayActiveUsersMetric.php
+++ b/src/OneDayActiveUsersMetric.php
@@ -34,9 +34,9 @@ class OneDayActiveUsersMetric extends Trend
     public function ranges(): array
     {
         return [
-            5 => '5 Days',
-            10 => '10 Days',
-            15 => '15 Days',
+            5 => __('5 Days'),
+            10 => __('10 Days'),
+            15 => __('15 Days'),
         ];
     }
 

--- a/src/SevenDayActiveUsersMetric.php
+++ b/src/SevenDayActiveUsersMetric.php
@@ -34,9 +34,9 @@ class SevenDayActiveUsersMetric extends Trend
     public function ranges(): array
     {
         return [
-            5 => '5 Days',
-            10 => '10 Days',
-            15 => '15 Days',
+            5 => __('5 Days'),
+            10 => __('10 Days'),
+            15 => __('15 Days'),
         ];
     }
 

--- a/src/TwentyEightDayActiveUsersMetric.php
+++ b/src/TwentyEightDayActiveUsersMetric.php
@@ -34,9 +34,9 @@ class TwentyEightDayActiveUsersMetric extends Trend
     public function ranges(): array
     {
         return [
-            5 => '5 Days',
-            10 => '10 Days',
-            15 => '15 Days',
+            5 => __('5 Days'),
+            10 => __('10 Days'),
+            15 => __('15 Days'),
         ];
     }
 


### PR DESCRIPTION
This pull request updates the list of ranges for metrics to wrap in a translatable string.

```
public function ranges(): array
    {
        return [
            5 => __('5 Days'),
            10 => __('10 Days'),
            15 => __('15 Days'),
        ];
    }
```